### PR TITLE
Fix Travis matrix/jobs conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,14 @@ julia:
   - 1.3
   - 1.4
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
 notifications:
   email: false
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
   include:
     - stage: Documentation
       julia: 1.3


### PR DESCRIPTION
This seems to come up some times but not others. Travis has made it so if you have both `matrix` and `jobs`, `jobs` is discarded. I don't know why. In any case, the modern way is to never use `matrix` for anything.