### PR TITLE
Remove return which breaks testsets

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Models"
 uuid = "e6388cff-ecff-480c-9b53-83211bf7812a"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Models"
 uuid = "e6388cff-ecff-480c-9b53-83211bf7812a"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -131,7 +131,7 @@ Returns the predictions of the `Model`.
 """
 function test_interface(template::Template; kwargs...)
     @testset "Models API Interface Test: $(nameof(typeof(template)))" begin
-        return test_interface(template, estimate_type(template), output_type(template); kwargs...)
+        test_interface(template, estimate_type(template), output_type(template); kwargs...)
     end
 end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -126,8 +126,6 @@ StatsBase.predict(m::FakeModel, inputs) = m.predictor(m.num_variates, inputs)
 
 Test that subtypes of [`Template`](@ref) and [`Model`](@ref) implement the expected API.
 Can be used as an initial test to verify the API has been correctly implemented.
-
-Returns the predictions of the `Model`.
 """
 function test_interface(template::Template; kwargs...)
     @testset "Models API Interface Test: $(nameof(typeof(template)))" begin


### PR DESCRIPTION
Closes #15 

Gives correct behaviour in the following situation:
```julia
julia> results = @testset "test" begin
              test_interface(FakeTemplate{PointEstimate, SingleOutput}())
              @test false
           end
test: Test Failed at REPL[3]:3
  Expression: false
Stacktrace:
 [1] top-level scope at REPL[3]:3
 [2] top-level scope at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/Test/src/Test.jl:1113
 [3] top-level scope at REPL[3]:2
Test Summary:                             | Pass  Fail  Total
test                                      |   13     1     14
  Models API Interface Test: FakeTemplate |   13           13
ERROR: Some tests did not pass: 13 passed, 1 failed, 0 errored, 0 broken.

julia> results.anynonpass
ERROR: UndefVarError: results not defined
```