### PR TITLE
Remove references to posterior

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Models"
 uuid = "e6388cff-ecff-480c-9b53-83211bf7812a"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -68,7 +68,7 @@ end
 """
     FakeTemplate{DistributionEstimate, SingleOutput}()
 
-A [`Template`](@ref) whose [`Model`](@ref) will predict a univariate normal posterior
+A [`Template`](@ref) whose [`Model`](@ref) will predict a univariate normal
 distribution (with zero mean and unit standard deviation) for each observation.
 """
 function FakeTemplate{DistributionEstimate, SingleOutput}()
@@ -82,7 +82,7 @@ end
 """
     FakeTemplate{DistributionEstimate, MultiOutput}()
 
-A [`Template`](@ref) whose [`Model`](@ref) will predict a multivariate normal posterior
+A [`Template`](@ref) whose [`Model`](@ref) will predict a multivariate normal
 distribution (with zero-vector mean and identity covariance matrix) for each observation.
 """
 function FakeTemplate{DistributionEstimate, MultiOutput}()

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -17,7 +17,7 @@ abstract type PointEstimate <: EstimateTrait end
 """
     DistributionEstimate <: EstimateTrait
 
-Specifies that the [`Model`](@ref) returns a posterior distribution over the response variables.
+Specifies that the [`Model`](@ref) returns a distribution over the response variables.
 """
 abstract type DistributionEstimate <: EstimateTrait end
 


### PR DESCRIPTION
This language was unhelpful -- the interpretation of the distribution that is produced needn't be that it is a "posterior" -- it's just _some_ distribution.