### PR TITLE
Clarify `predict` docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Models"
 uuid = "e6388cff-ecff-480c-9b53-83211bf7812a"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -30,7 +30,7 @@ One does not have to carry both a [`Model`](@ref) type, and a varying collection
 
 ```julia
 model = StatsBase.fit(
-    template,
+    template::Template,
     outputs::AbstractMatrix,  # always Features x Observations
     inputs::AbstractMatrix,   # always Variates x Observations
     weights=uweights(Float32, size(outputs, 2))
@@ -38,10 +38,17 @@ model = StatsBase.fit(
 ```
 
 ```julia
+# estimate_type(model) == PointEsimate
 outputs = StatsBase.predict(
-    model,
+    model::Model,
     inputs::AbstractMatrix  # always Features x Observations
 )::AbstractMatrix  # always Variates x Observations
+
+# estimate_type(model) == DistributionEstimate
+outputs = StatsBase.predict(
+    model::Model,
+    inputs::AbstractMatrix  # always Features x Observations
+)::AbstractVector{<:Distribution}  # length Observations
 ```
 
 [`fit`](@ref) takes in a [`Template`](@ref) and some *data* and returns a [`Model`](@ref) that has been fit to the data.

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -28,7 +28,7 @@ Defined as well are the traits:
 abstract type Model end
 
 """
-   fit(::Template, output, input, [weights]) -> Model
+   fit(::Template, output::AbstractMatrix, input::AbstractMatrix, [weights]) -> Model
 
 Fit the [`Template`](@ref) to the `output` and `input` data and return a trained
 [`Model`](@ref).
@@ -37,19 +37,15 @@ Convention is that `weights` defaults to `StatsBase.uweights(Float32, size(outpu
 function fit end
 
 """
-    predict(model::Model, inputs)
+    predict(model::Model, inputs::AbstractMatrix)
 
-Predict targets for the provided the collection of `inputs` and [`Model`](@ref). Canonical
-`inputs` representation is an `AbstractMatrix` for which each column represents a single
-input.
+Predict targets for the provided the collection of `inputs` and [`Model`](@ref).
 
 If the `estimate_type(model) == [`PointEstimate`](@ref) then this function should return
 another `AbstractMatrix` in which each column contains the prediction for a single input.
 
 If the `estimate_type(model) == [`DistributionEstimate`](@ref) then this function should
 return a `Vector{<:Distribution}`.
-
-Returns a predictive distribution or point estimates depending on the [`Model`](@ref).
 """
 function predict end
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -44,7 +44,7 @@ Predict targets for the provided the collection of `inputs` and [`Model`](@ref).
 If the `estimate_type(model)` is [`PointEstimate`](@ref) then this function should return
 another `AbstractMatrix` in which each column contains the prediction for a single input.
 
-If the `estimate_type(model) == [`DistributionEstimate`](@ref) then this function should
+If the `estimate_type(model)` is [`DistributionEstimate`](@ref) then this function should
 return a `AbstractVector{<:Distribution}`.
 """
 function predict end

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -37,9 +37,17 @@ Convention is that `weights` defaults to `StatsBase.uweights(Float32, size(outpu
 function fit end
 
 """
-    predict(::Model, input)
+    predict(model::Model, inputs)
 
-Predict targets for the provided `input` and [`Model`](@ref).
+Predict targets for the provided the collection of `inputs` and [`Model`](@ref). Canonical
+`inputs` representation is an `AbstractMatrix` for which each column represents a single
+input.
+
+If the `estimate_type(model) == [`PointEstimate`](@ref) then this function should return
+another `AbstractMatrix` in which each column contains the prediction for a single input.
+
+If the `estimate_type(model) == [`DistributionEstimate`](@ref) then this function should
+return a `Vector{<:Distribution}`.
 
 Returns a predictive distribution or point estimates depending on the [`Model`](@ref).
 """

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -45,7 +45,7 @@ If the `estimate_type(model) == [`PointEstimate`](@ref) then this function shoul
 another `AbstractMatrix` in which each column contains the prediction for a single input.
 
 If the `estimate_type(model) == [`DistributionEstimate`](@ref) then this function should
-return a `Vector{<:Distribution}`.
+return a `AbstractVector{<:Distribution}`.
 """
 function predict end
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -41,7 +41,7 @@ function fit end
 
 Predict targets for the provided the collection of `inputs` and [`Model`](@ref).
 
-If the `estimate_type(model) == [`PointEstimate`](@ref) then this function should return
+If the `estimate_type(model)` is [`PointEstimate`](@ref) then this function should return
 another `AbstractMatrix` in which each column contains the prediction for a single input.
 
 If the `estimate_type(model) == [`DistributionEstimate`](@ref) then this function should


### PR DESCRIPTION
This PR clarifies what is supposed to happen with `predict`.

- clarifies the docstring for `predict` to highlight what it should return, and that it should accept a _collection_ of inputs, rather than a single input.
- clarifies the documentation regarding the return type of `predict` for models that produce `DistributionEstimate`s. This now reflects what we've actually been doing in `BaselineModels`, which I believe to be very reasonable.