### PR TITLE
Fix CI Tests and Artifact Cache Issues

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,41 +15,42 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1
+          - "1.0"  # LTS
+          - "1"    # Latest Release
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
         arch:
           - x64
-        include:
-          # Add a 1.0 job just to make sure we still support it
-          - os: ubuntu-latest
-            version: 1.0.5
-            arch: x64
-          # Add a 1.3 job because that's what Invenia actually uses
-          - os: ubuntu-latest
-            version: 1.3
-            arch: x64
-          # Add a 32-bit job to ensure we don't have any 64-bit specific logic
-          - os: ubuntu-latest
-            version: 1
+          - x86
+        exclude:
+          # Test 32-bit only on Linux
+          - os: macOS-latest
             arch: x86
+          - os: windows-latest
+            arch: x86
+        include:
+          # Add a 1.5 job because that's what Invenia actually uses
+          - os: ubuntu-latest
+            version: 1.5
+            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.arch }}-test-
+            ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,9 +53,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
-      - run: |
-          git config --global user.name Tester
-          git config --global user.email te@st.er
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
@@ -66,13 +63,13 @@ jobs:
     name: Notify Slack Failure
     needs: test
     runs-on: ubuntu-latest
-    if: github.event == 'schedule'
+    if: always() && github.event_name == 'schedule'
     steps:
       - uses: technote-space/workflow-conclusion-action@v2
       - uses: voxmedia/github-action-slack-notify-build@v1
         if: env.WORKFLOW_CONCLUSION == 'failure'
         with:
-          channel: nightly-dev
+          channel: nightly-rse
           status: FAILED
           color: danger
         env:
@@ -87,15 +84,11 @@ jobs:
         with:
           version: '1'
       - run: |
-          git config --global user.name name
-          git config --global user.email email
-          git config --global github.user username
-      - run: |
           julia --project=docs -e '
-            using Pkg;
-            Pkg.develop(PackageSpec(path=pwd()));
-            Pkg.instantiate();
-            include("docs/make.jl");'
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            include("docs/make.jl")'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -22,9 +22,6 @@ jobs:
           restore-keys: |
             ${{ env.cache-name }}-
       - uses: julia-actions/julia-buildpkg@latest
-      - run: |
-          git config --global user.name Tester
-          git config --global user.email te@st.er
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -13,16 +13,14 @@ jobs:
         with:
           version: nightly
           arch: x64
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
-          cache-name: cache-artifacts
+          cache-name: julia-nightly-cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+            ${{ env.cache-name }}-
       - uses: julia-actions/julia-buildpkg@latest
       - run: |
           git config --global user.name Tester


### PR DESCRIPTION
Use CLI script to automatically replace the 1.3 test with a 1.5 test (if necessary), as well as use new cache steps to cache the julia build artifacts