### PR TITLE
Add PredictInputTrait to Models API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Models"
 uuid = "e6388cff-ecff-480c-9b53-83211bf7812a"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.3.0"
+version = "0.2.5"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Models"
 uuid = "e6388cff-ecff-480c-9b53-83211bf7812a"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,6 +13,7 @@ predict
 submodels
 estimate_type
 output_type
+predict_input_type
 ```
 
 ## Traits

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,4 +23,8 @@ DistributionEstimate
 OutputTrait
 SingleOutput
 MultiOutput
+PredictInputTrait
+PointPredictInput
+DistributionPredictInput
+PointOrDistributionPredictInput
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -26,6 +26,5 @@ SingleOutput
 MultiOutput
 PredictInputTrait
 PointPredictInput
-DistributionPredictInput
 PointOrDistributionPredictInput
 ```

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -74,7 +74,6 @@ Here are the current [`Model`](@ref) traits in use and their possible values:
    - [`MultiOutput`](@ref): Fits and predicts on multiple outputs at a time.
  - [`predict_input_type`](@ref) - determines which datatypes a [`Model`](@ref) can accept at predict time.
    - [`PointPredictInput`](@ref): Real valued input variables accepted at predict time.
-   - [`DistributionPredictInput`](@ref): Distributions over input variables accepted at predict time.
    - [`PointOrDistributionPredictInput`](@ref): Either real valued or distributions of input variables accepted at predict time.
 
 The traits always agree between the [`Model`](@ref) and the [`Template`](@ref).

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -79,7 +79,7 @@ Here are the current [`Model`](@ref) traits in use and their possible values:
 
 The traits always agree between the [`Model`](@ref) and the [`Template`](@ref).
 Every [`Model`](@ref) and [`Template`](@ref) should define all the listed traits.
-If left undefined, the ['PredictInputTrait'](@ref) will have the default value of [`PointPredictInput`](@ref).
+If left undefined, the [`PredictInputTrait`](@ref) will have the default value of [`PointPredictInput`](@ref).
 
 This package uses traits implemented such that the trait function returns an `abstract type` (rather than an instance).
 That means to check a trait one uses:

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -72,9 +72,14 @@ Here are the current [`Model`](@ref) traits in use and their possible values:
  - [`output_type`](@ref) - determines how many output variates a [`Model`](@ref) can learn
    - [`SingleOutput`](@ref): Fits and predicts on a single output only.
    - [`MultiOutput`](@ref): Fits and predicts on multiple outputs at a time.
+ - [`predict_input_type`](@ref) - determines which datatypes a [`Model`](@ref) can accept at predict time.
+   - [`PointPredictInput`](@ref): Real valued input variables accepted at predict time.
+   - [`DistributionPredictInput`](@ref): Distributions over input variables accepted at predict time.
+   - [`PointOrDistributionPredictInput`](@ref): Either real valued or distributions of input variables accepted at predict time.
 
 The traits always agree between the [`Model`](@ref) and the [`Template`](@ref).
 Every [`Model`](@ref) and [`Template`](@ref) should define all the listed traits.
+If left undefined, the ['PredictInputTrait'](@ref) will have the default value of [`PointPredictInput`](@ref).
 
 This package uses traits implemented such that the trait function returns an `abstract type` (rather than an instance).
 That means to check a trait one uses:

--- a/docs/src/testutils.md
+++ b/docs/src/testutils.md
@@ -12,7 +12,7 @@ test_interface
 ### Note on PredictInputTrait Interface Tests
 
 In the case where the [`PredictInputTrait`](@ref) is [`DistributionPredictInput`](@ref) or [`PointOrDistributionPredictInput`](@ref) the the Models API requires only that the distribution in question is `Sampleable`.
-When using `Models.TestUtils.test_interface` to test a model where distributions can be passed to `predict`, the user should provide `inputs` of the distribution type appropriate to their model.
+When using [`Models.TestUtils.test_interface`](@ref) to test a model where distributions can be passed to [`predict`](@ref), the user should provide `inputs` of the distribution type appropriate to their model.
 In the example below the `CustomModel` accepts `MvNormal` distributions to `predict`.  
 
 ```julia

--- a/docs/src/testutils.md
+++ b/docs/src/testutils.md
@@ -11,7 +11,7 @@ test_interface
 
 ### Note on PredictInputTrait Interface Tests
 
-In the case where the [`PredictInputTrait`](@ref) is [`DistributionPredictInput`](@ref) or [`PointOrDistributionPredictInput`](@ref) the the Models API requires only that the distribution in question is `Sampleable`.
+In the case where the [`PredictInputTrait`](@ref) is [`PointOrDistributionPredictInput`](@ref) the the Models API requires only that the distribution in question is `Sampleable`.
 When using [`Models.TestUtils.test_interface`](@ref) to test a model where distributions can be passed to [`predict`](@ref), the user should provide `inputs` of the distribution type appropriate to their model.
 In the example below the `CustomModel` accepts `MvNormal` distributions to `predict`.  
 

--- a/docs/src/testutils.md
+++ b/docs/src/testutils.md
@@ -9,6 +9,23 @@ TestUtils
 test_interface
 ```
 
+### Note on PredictInputTrait Interface Tests
+
+In the case where the [`PredictInputTrait`](@ref) is [`DistributionPredictInput`](@ref) or [`PointOrDistributionPredictInput`](@ref) the the Models API requires only that the distribution in question is `Sampleable`.
+When using `Models.TestUtils.test_interface` to test a model where distributions can be passed to `predict`, the user should provide `inputs` of the distribution type appropriate to their model.
+In the example below the `CustomModel` accepts `MvNormal` distributions to `predict`.  
+
+```julia
+using CustomModels
+using Distributions
+using Models.TestUtils
+
+test_interface(
+    CustomModelTemplate();
+    distribution_inputs=[MvNormal(5, 1) for _ in 1:5],
+)
+```
+
 ## Test Fakes
 ```@autodocs
 Modules = [Models.TestUtils]

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -3,10 +3,13 @@ module Models
 import StatsBase: fit, predict
 
 export Model, Template
-export fit, predict, submodels, estimate_type, output_type, inject_type
+export fit, predict, submodels, estimate_type, output_type, predict_input_type
 export EstimateTrait, PointEstimate, DistributionEstimate
 export OutputTrait, SingleOutput, MultiOutput
-export InjectTrait, PointInject, DistributionInject, PointOrDistributionInject
+export PredictInputTrait, 
+   PointPredictInput, 
+   DistributionPredictInput, 
+   PointOrDistributionPredictInput
 
 """
    Template

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -55,7 +55,7 @@ return a `AbstractVector{<:Distribution}`.
 function predict end
 
 function predict(model::Model, inputs::AbstractVector{<:AbstractVector})
-   return predict(model, hcat(inputs...))
+   return predict(model, reduce(hcat, inputs))
 end
 
 """

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -46,6 +46,10 @@ function fit end
 
 Predict targets for the provided the collection of `inputs` and [`Model`](@ref).
 
+A [`Model`](@ref) subtype for which the `predict_input_type(model)` is 
+[`PointPredictInput`](@ref) will only need to implement a `predict` function that operates 
+on an `AbstractMatrix` of inputs.  
+
 If the `estimate_type(model)` is [`PointEstimate`](@ref) then this function should return
 another `AbstractMatrix` in which each column contains the prediction for a single input.
 

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -6,6 +6,7 @@ export Model, Template
 export fit, predict, submodels, estimate_type, output_type
 export EstimateTrait, PointEstimate, DistributionEstimate
 export OutputTrait, SingleOutput, MultiOutput
+export InputTrait, PointInput, DistributionInput
 
 """
    Template

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -6,10 +6,7 @@ export Model, Template
 export fit, predict, submodels, estimate_type, output_type, predict_input_type
 export EstimateTrait, PointEstimate, DistributionEstimate
 export OutputTrait, SingleOutput, MultiOutput
-export PredictInputTrait, 
-   PointPredictInput, 
-   DistributionPredictInput, 
-   PointOrDistributionPredictInput
+export PredictInputTrait, PointPredictInput, PointOrDistributionPredictInput
 
 """
    Template

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -3,10 +3,10 @@ module Models
 import StatsBase: fit, predict
 
 export Model, Template
-export fit, predict, submodels, estimate_type, output_type
+export fit, predict, submodels, estimate_type, output_type, inject_type
 export EstimateTrait, PointEstimate, DistributionEstimate
 export OutputTrait, SingleOutput, MultiOutput
-export InputTrait, PointInput, DistributionInput
+export InjectTrait, PointInject, DistributionInject, PointOrDistributionInject
 
 """
    Template

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -39,6 +39,7 @@ function fit end
 
 """
     predict(model::Model, inputs::AbstractMatrix)
+    predict(model::Model, inputs::AbstractVector{<:AbstractVector})
 
 Predict targets for the provided the collection of `inputs` and [`Model`](@ref).
 
@@ -49,6 +50,10 @@ If the `estimate_type(model)` is [`DistributionEstimate`](@ref) then this functi
 return a `AbstractVector{<:Distribution}`.
 """
 function predict end
+
+function predict(model::Model, inputs::AbstractVector{<:AbstractVector})
+   return predict(model, hcat(inputs...))
+end
 
 """
     submodels(::Union{Template, Model})

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -122,7 +122,7 @@ function FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInje
     end
 end
 
-_handle_inputs(inputs::AbstractVector{<:Normal}) = mean.(inputs)
+_handle_inputs(inputs::AbstractVector{<:Sampleable}) = mean.(inputs)
 _handle_inputs(inputs::AbstractMatrix) = [mean(inputs[m, :]) for m in 1:size(inputs, 2)]
 
 """
@@ -155,7 +155,7 @@ function StatsBase.fit(
 end
 
 StatsBase.predict(m::FakeModel, inputs::AbstractMatrix) = m.predictor(m.num_variates, inputs)
-StatsBase.predict(m::FakeModel, inputs::AbstractVector{<:Normal}) = m.predictor(m.num_variates, inputs)
+StatsBase.predict(m::FakeModel, inputs::AbstractVector{<:Sampleable}) = m.predictor(m.num_variates, inputs)
 
 """
     test_interface(template::Template; inputs=rand(5, 5), outputs=rand(5, 5))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -121,7 +121,7 @@ function FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInje
 end
 
 _handle_inputs(inputs::AbstractVector{<:Normal}) = mean.(inputs)
-_handle_inputs(inputs::AbstractMatrix) = only([mean(inputs[:, m]) for m in 1:size(inputs, 2)])
+_handle_inputs(inputs::AbstractMatrix) = [mean(inputs[m, :]) for m in 1:size(inputs, 2)]
 
 """
     FakeModel
@@ -220,18 +220,16 @@ function test_interface(
     @test predictions isa AbstractVector{<:ContinuousMultivariateDistribution}
     @test length(predictions) == size(outputs, 2)
     @test all(length.(predictions) .== size(outputs, 1))
-    @test mean.(mean.(predictions)) == [i for i in 1:5]
 end
 
 function test_interface(
     template::Template, ::Type{DistributionEstimate}, ::Type{MultiOutput}, ::Type{PointOrDistributionInject};
-    inputs=[Normal(m, 1) for m in 1:5], outputs=rand(3, 5)
+    inputs=hcat([[i for i in 1:5] for j in 1:5]...), outputs=rand(3, 5)
 )
     predictions = test_common(template, inputs, outputs)
     @test predictions isa AbstractVector{<:ContinuousMultivariateDistribution}
     @test length(predictions) == size(outputs, 2)
     @test all(length.(predictions) .== size(outputs, 1))
-    @test mean.(mean.(predictions)) == [i for i in 1:5]
 end
 
 function test_names(template, model)

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -160,14 +160,9 @@ function test_interface(
     end
 end
 
-function _default_outputs(template)
-    @assert(output_type(template) <: OutputTrait, "Invalid OutputTrait")
-    if output_type(template) == SingleOutput
-        return rand(1, 5)
-    else output_type(template) == MultiOutput
-        return rand(2, 5)
-    end
-end
+_default_outputs(template) = _default_outputs(output_type(template), template)
+_default_outputs(::Type{SingleOutput}, template) = rand(1, 5)
+_default_outputs(::Type{MultiOutput}, template) = rand(2, 5)
 
 function test_estimate_type(::Type{PointEstimate}, predictions, outputs)
     @test predictions isa NamedDimsArray{(:variates, :observations), <:Real, 2}

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -160,9 +160,9 @@ function test_interface(
     end
 end
 
-_default_outputs(template) = _default_outputs(output_type(template), template)
-_default_outputs(::Type{SingleOutput}, template) = rand(1, 5)
-_default_outputs(::Type{MultiOutput}, template) = rand(2, 5)
+_default_outputs(template) = _default_outputs(output_type(template))
+_default_outputs(::Type{SingleOutput}) = rand(1, 5)
+_default_outputs(::Type{MultiOutput}) = rand(2, 5)
 
 function test_estimate_type(::Type{PointEstimate}, predictions, outputs)
     @test predictions isa NamedDimsArray{(:variates, :observations), <:Real, 2}

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -60,43 +60,43 @@ output_type(::T) where T = output_type(T)
 output_type(T::Type) = throw(MethodError(output_type, (T,)))  # to prevent recursion
 
 """
-    InjectTrait
+    PredictInputTrait
 
-The `InjectTrait` specifies if the model supports point or distribution injections to predict,
-denoted by [`PointInject`](@ref) or [`DistributionInject`](@ref), respectively.  A model can
-also be implemented in such a way as to allow [`PointOrDistributionInject`](@ref).
+The `PredictInputTrait` specifies if the model supports point or distribution injections to predict,
+denoted by [`PointPredictInput`](@ref) or [`DistributionPredictInput`](@ref), respectively.  A model can
+also be implemented in such a way as to allow [`PointOrDistributionPredictInput`](@ref).
 """
-abstract type InjectTrait end
+abstract type PredictInputTrait end
 
 """
-    PointInject <: InjectTrait
+    PointPredictInput <: PredictInputTrait
 
 Specifies that the [`Model`](@ref) accepts real-valued input variables to `predict`.
 """
-abstract type PointInject <: InjectTrait end
+abstract type PointPredictInput <: PredictInputTrait end
 
 """
-    DistributionInject <: InjectTrait
+    DistributionPredictInput <: PredictInputTrait
 
 Specifies that the [`Model`](@ref) accepts a distribution over the input variables to `predict`.
 """
-abstract type DistributionInject <: InjectTrait end
+abstract type DistributionPredictInput <: PredictInputTrait end
 
 """
-    PointOrDistributionInject <: InjectTrait
+    PointOrDistributionPredictInput <: PredictInputTrait
 
 Specifies that the [`Model`](@ref) accepts real-values or a distribution over the input 
 variables to `predict`.
 """
-abstract type PointOrDistributionInject <: InjectTrait end
+abstract type PointOrDistributionPredictInput <: PredictInputTrait end
 
 """
-    inject_type(::T) where T = inject_type(T)
+    predict_input_type(::T) where T = predict_input_type(T)
 
-Return the [`InjectTrait`] of the [`Model`](@ref) or [`Template`](@ref).
+Return the [`PredictInputTrait`] of the [`Model`](@ref) or [`Template`](@ref).
 """
-inject_type(::T) where T = inject_type(T)
-inject_type(T::Type) = throw(MethodError(inject_type, (T,)))  # to prevent recursion
+predict_input_type(::T) where T = predict_input_type(T)
+predict_input_type(T::Type) = throw(MethodError(predict_input, (T,)))  # to prevent recursion
 
-inject_type(::Type{<:Model}) = PointInject
-inject_type(::Type{<:Template}) = PointInject
+predict_input_type(::Type{<:Model}) = PointPredictInput
+predict_input_type(::Type{<:Template}) = PointPredictInput

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -60,31 +60,42 @@ output_type(::T) where T = output_type(T)
 output_type(T::Type) = throw(MethodError(output_type, (T,)))  # to prevent recursion
 
 """
-    InputTrait
+    InjectTrait
 
-The `InputTrait` specifies if the model supports point or distribution inputs to predict,
-denoted by [`PointInput`](@ref) or [`DistributionInput`](@ref), respectively.
+The `InjectTrait` specifies if the model supports point or distribution injections to predict,
+denoted by [`PointInject`](@ref) or [`DistributionInject`](@ref), respectively.
 """
-abstract type InputTrait end
+abstract type InjectTrait end
 
 """
-    PointInput <: InputTrait
+    PointInject <: InjectTrait
 
 Specifies that the [`Model`](@ref) accepts real-valued input variables to `predict`.
 """
-abstract type PointInput <: InputTrait end
+abstract type PointInject <: InjectTrait end
 
 """
-    DistributionInput <: InputTrait
+    DistributionInject <: InjectTrait
 
 Specifies that the [`Model`](@ref) accepts a distribution over the input variables to `predict`.
 """
-abstract type DistributionInput <: InputTrait end
+abstract type DistributionInject <: InjectTrait end
 
 """
-    input_type(::T) where T = input_type(T)
+    PointOrDistributionInject <: InjectTrait
 
-Return the [`InputTrait`] of the [`Model`](@ref) or [`Template`](@ref).
+Specifies that the [`Model`](@ref) accepts real-values or a distribution over the input 
+variables to `predict`.
 """
-input_type(::T) where T = input_type(T)
-input_type(T::Type) = throw(MethodError(input_type, (T,)))  # to prevent recursion
+abstract type PointOrDistributionInject <: InjectTrait end
+
+"""
+    inject_type(::T) where T = inject_type(T)
+
+Return the [`InjectTrait`] of the [`Model`](@ref) or [`Template`](@ref).
+"""
+inject_type(::T) where T = inject_type(T)
+inject_type(T::Type) = throw(MethodError(inject_type, (T,)))  # to prevent recursion
+
+inject_type(::Type{<:Model}) = PointInject
+inject_type(::Type{<:Template}) = PointInject

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -63,8 +63,7 @@ output_type(T::Type) = throw(MethodError(output_type, (T,)))  # to prevent recur
     PredictInputTrait
 
 The `PredictInputTrait` specifies if the model supports point or distribution injections to predict,
-denoted by [`PointPredictInput`](@ref) or [`DistributionPredictInput`](@ref), respectively.  A model can
-also be implemented in such a way as to allow [`PointOrDistributionPredictInput`](@ref).
+denoted by [`PointPredictInput`](@ref) or [`PointOrDistributionPredictInput`](@ref).
 """
 abstract type PredictInputTrait end
 
@@ -74,13 +73,6 @@ abstract type PredictInputTrait end
 Specifies that the [`Model`](@ref) accepts real-valued input variables to `predict`.
 """
 abstract type PointPredictInput <: PredictInputTrait end
-
-"""
-    DistributionPredictInput <: PredictInputTrait
-
-Specifies that the [`Model`](@ref) accepts a distribution over the input variables to `predict`.
-"""
-abstract type DistributionPredictInput <: PredictInputTrait end
 
 """
     PointOrDistributionPredictInput <: PredictInputTrait

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -62,7 +62,7 @@ output_type(T::Type) = throw(MethodError(output_type, (T,)))  # to prevent recur
 """
     PredictInputTrait
 
-The `PredictInputTrait` specifies if the model supports point or distribution injections to predict,
+The `PredictInputTrait` specifies if the model supports point or distribution inputs to `predict`,
 denoted by [`PointPredictInput`](@ref) or [`PointOrDistributionPredictInput`](@ref).
 """
 abstract type PredictInputTrait end
@@ -77,7 +77,7 @@ abstract type PointPredictInput <: PredictInputTrait end
 """
     PointOrDistributionPredictInput <: PredictInputTrait
 
-Specifies that the [`Model`](@ref) accepts real-values or a distribution over the input 
+Specifies that the [`Model`](@ref) accepts real-values or a joint distribution over the input 
 variables to `predict`.
 """
 abstract type PointOrDistributionPredictInput <: PredictInputTrait end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -58,3 +58,33 @@ Return the [`OutputTrait`] of the [`Model`](@ref) or [`Template`](@ref).
 """
 output_type(::T) where T = output_type(T)
 output_type(T::Type) = throw(MethodError(output_type, (T,)))  # to prevent recursion
+
+"""
+    InputTrait
+
+The `InputTrait` specifies if the model supports point or distribution inputs to predict,
+denoted by [`PointInput`](@ref) or [`DistributionInput`](@ref), respectively.
+"""
+abstract type InputTrait end
+
+"""
+    PointInput <: InputTrait
+
+Specifies that the [`Model`](@ref) accepts real-valued input variables to `predict`.
+"""
+abstract type PointInput <: InputTrait end
+
+"""
+    DistributionInput <: InputTrait
+
+Specifies that the [`Model`](@ref) returns a distribution over the input vairables to `predict`.
+"""
+abstract type DistributionInput <: InputTrait end
+
+"""
+    input_type(::T) where T = input_type(T)
+
+Return the [`InputTrait`] of the [`Model`](@ref) or [`Template`](@ref).
+"""
+input_type(::T) where T = input_type(T)
+input_type(T::Type) = throw(MethodError(input_type, (T,)))  # to prevent recursion

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -63,7 +63,8 @@ output_type(T::Type) = throw(MethodError(output_type, (T,)))  # to prevent recur
     InjectTrait
 
 The `InjectTrait` specifies if the model supports point or distribution injections to predict,
-denoted by [`PointInject`](@ref) or [`DistributionInject`](@ref), respectively.
+denoted by [`PointInject`](@ref) or [`DistributionInject`](@ref), respectively.  A model can
+also be implemented in such a way as to allow [`PointOrDistributionInject`](@ref).
 """
 abstract type InjectTrait end
 

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -77,7 +77,7 @@ abstract type PointInput <: InputTrait end
 """
     DistributionInput <: InputTrait
 
-Specifies that the [`Model`](@ref) returns a distribution over the input vairables to `predict`.
+Specifies that the [`Model`](@ref) accepts a distribution over the input variables to `predict`.
 """
 abstract type DistributionInput <: InputTrait end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -30,10 +30,10 @@
 
     @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}" begin
         temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
-        test_interface(temp)
+        test_interface(temp; inputs=[Normal(m, 1) for m in 1:5], outputs=rand(3, 5))
 
         temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
-        test_interface(temp; inputs=hcat([[i for i in 1:5] for j in 1:5]), outputs=rand(3, 5))
+        test_interface(temp)
     end
 
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -23,8 +23,38 @@
         test_interface(temp)
     end
 
+    @testset "FakeTemplate{PointEstimate, SingleOutput, DistributionPredictInput}" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput, DistributionPredictInput}()
+        test_interface(temp)
+    end
+
+    @testset "FakeTemplate{PointEstimate, MultiOutput, DistributionPredictInput}" begin
+        temp = FakeTemplate{PointEstimate, MultiOutput, DistributionPredictInput}()
+        test_interface(temp)
+    end
+
+    @testset "FakeTemplate{DistributionEstimate, SingleOutput, DistributionPredictInput}" begin
+        temp = FakeTemplate{DistributionEstimate, SingleOutput, DistributionPredictInput}()
+        test_interface(temp)
+    end
+
     @testset "FakeTemplate{DistributionEstimate, MultiOutput, DistributionPredictInput}" begin
         temp = FakeTemplate{DistributionEstimate, MultiOutput, DistributionPredictInput}()
+        test_interface(temp)
+    end
+
+    @testset "FakeTemplate{PointEstimate, SingleOutput, PointOrDistributionPredictInput}" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput, PointOrDistributionPredictInput}()
+        test_interface(temp)
+    end
+
+    @testset "FakeTemplate{PointEstimate, MultiOutput, PointOrDistributionPredictInput}" begin
+        temp = FakeTemplate{PointEstimate, MultiOutput, PointOrDistributionPredictInput}()
+        test_interface(temp)
+    end
+
+    @testset "FakeTemplate{DistributionEstimate, SingleOutput, PointOrDistributionPredictInput}" begin
+        temp = FakeTemplate{DistributionEstimate, SingleOutput, PointOrDistributionPredictInput}()
         test_interface(temp)
     end
 
@@ -32,5 +62,4 @@
         temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionPredictInput}()
         test_interface(temp)
     end
-
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -30,9 +30,6 @@
 
     @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}" begin
         temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
-        test_interface(temp; inputs=[Normal(m, 1) for m in 1:5], outputs=rand(3, 5))
-
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
         test_interface(temp)
     end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -3,6 +3,9 @@
     @testset "FakeTemplate{PointEstimate, SingleOutput, PointInject}" begin
         temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
         test_interface(temp)
+
+        temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
+        test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
     end
 
     @testset "FakeTemplate{PointEstimate, MultiOutput, PointInject}" begin
@@ -20,13 +23,17 @@
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{PointEstimate, SingleOutput, PointInject} with Vector{<:Vector}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
-        test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
-    end
-
     @testset "FakeTemplate{DistributionEstimate, MultiOutput, DistributionInject}" begin
         temp = FakeTemplate{DistributionEstimate, MultiOutput, DistributionInject}()
         test_interface(temp)
     end
+
+    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}" begin
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
+        test_interface(temp)
+
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
+        test_interface(temp; inputs=hcat([[i for i in 1:5] for j in 1:5]), outputs=rand(3, 5))
+    end
+
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -20,4 +20,9 @@
         test_interface(temp)
     end
 
+    @testset "FakeTemplate{PointEstimate, SingleOutput} with Vector{<:Vector}" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput}()
+        test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
+    end
+
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,65 +1,17 @@
 @testset "test_utils.jl" begin
 
-    @testset "FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}()
-        test_interface(temp)
+    estimates = (PointEstimate, DistributionEstimate)
+    outputs = (SingleOutput, MultiOutput)
+    predict_inputs = (PointPredictInput, DistributionPredictInput, PointOrDistributionPredictInput)
 
+    @testset "$est, $out, $pin" for (est, out, pin) in Iterators.product(estimates, outputs, predict_inputs)
+        temp = FakeTemplate{est, out, pin}()
+        test_interface(temp)
+    end    
+
+    @testset "Vector inputs case" begin
         temp = FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}()
         test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
     end
-
-    @testset "FakeTemplate{PointEstimate, MultiOutput, PointPredictInput}" begin
-        temp = FakeTemplate{PointEstimate, MultiOutput, PointPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{DistributionEstimate, SingleOutput, PointPredictInput}" begin
-        temp = FakeTemplate{DistributionEstimate, SingleOutput, PointPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointPredictInput}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{PointEstimate, SingleOutput, DistributionPredictInput}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput, DistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{PointEstimate, MultiOutput, DistributionPredictInput}" begin
-        temp = FakeTemplate{PointEstimate, MultiOutput, DistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{DistributionEstimate, SingleOutput, DistributionPredictInput}" begin
-        temp = FakeTemplate{DistributionEstimate, SingleOutput, DistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput, DistributionPredictInput}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, DistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{PointEstimate, SingleOutput, PointOrDistributionPredictInput}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput, PointOrDistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{PointEstimate, MultiOutput, PointOrDistributionPredictInput}" begin
-        temp = FakeTemplate{PointEstimate, MultiOutput, PointOrDistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{DistributionEstimate, SingleOutput, PointOrDistributionPredictInput}" begin
-        temp = FakeTemplate{DistributionEstimate, SingleOutput, PointOrDistributionPredictInput}()
-        test_interface(temp)
-    end
-
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionPredictInput}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionPredictInput}()
-        test_interface(temp)
-    end
+    
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,35 +1,35 @@
 @testset "test_utils.jl" begin
 
-    @testset "FakeTemplate{PointEstimate, SingleOutput, PointInject}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
+    @testset "FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}()
         test_interface(temp)
 
-        temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
+        temp = FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}()
         test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
     end
 
-    @testset "FakeTemplate{PointEstimate, MultiOutput, PointInject}" begin
-        temp = FakeTemplate{PointEstimate, MultiOutput, PointInject}()
+    @testset "FakeTemplate{PointEstimate, MultiOutput, PointPredictInput}" begin
+        temp = FakeTemplate{PointEstimate, MultiOutput, PointPredictInput}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{DistributionEstimate, SingleOutput, PointInject}" begin
-        temp = FakeTemplate{DistributionEstimate, SingleOutput, PointInject}()
+    @testset "FakeTemplate{DistributionEstimate, SingleOutput, PointPredictInput}" begin
+        temp = FakeTemplate{DistributionEstimate, SingleOutput, PointPredictInput}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointInject}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointInject}()
+    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointPredictInput}" begin
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointPredictInput}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput, DistributionInject}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, DistributionInject}()
+    @testset "FakeTemplate{DistributionEstimate, MultiOutput, DistributionPredictInput}" begin
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, DistributionPredictInput}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionInject}()
+    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionPredictInput}" begin
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointOrDistributionPredictInput}()
         test_interface(temp)
     end
 

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,7 +2,7 @@
 
     estimates = (PointEstimate, DistributionEstimate)
     outputs = (SingleOutput, MultiOutput)
-    predict_inputs = (PointPredictInput, DistributionPredictInput, PointOrDistributionPredictInput)
+    predict_inputs = (PointPredictInput, PointOrDistributionPredictInput)
 
     @testset "$est, $out, $pin" for (est, out, pin) in Iterators.product(estimates, outputs, predict_inputs)
         temp = FakeTemplate{est, out, pin}()
@@ -13,5 +13,5 @@
         temp = FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}()
         test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
     end
-    
+
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,28 +1,32 @@
 @testset "test_utils.jl" begin
 
-    @testset "FakeTemplate{PointEstimate, SingleOutput}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput}()
+    @testset "FakeTemplate{PointEstimate, SingleOutput, PointInject}" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{PointEstimate, MultiOutput}" begin
-        temp = FakeTemplate{PointEstimate, MultiOutput}()
+    @testset "FakeTemplate{PointEstimate, MultiOutput, PointInject}" begin
+        temp = FakeTemplate{PointEstimate, MultiOutput, PointInject}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{DistributionEstimate, SingleOutput}" begin
-        temp = FakeTemplate{DistributionEstimate, SingleOutput}()
+    @testset "FakeTemplate{DistributionEstimate, SingleOutput, PointInject}" begin
+        temp = FakeTemplate{DistributionEstimate, SingleOutput, PointInject}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{DistributionEstimate, MultiOutput}" begin
-        temp = FakeTemplate{DistributionEstimate, MultiOutput}()
+    @testset "FakeTemplate{DistributionEstimate, MultiOutput, PointInject}" begin
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, PointInject}()
         test_interface(temp)
     end
 
-    @testset "FakeTemplate{PointEstimate, SingleOutput} with Vector{<:Vector}" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput}()
+    @testset "FakeTemplate{PointEstimate, SingleOutput, PointInject} with Vector{<:Vector}" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput, PointInject}()
         test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
     end
 
+    @testset "FakeTemplate{DistributionEstimate, MultiOutput, DistributionInject}" begin
+        temp = FakeTemplate{DistributionEstimate, MultiOutput, DistributionInject}()
+        test_interface(temp)
+    end
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -2,16 +2,33 @@
 
     estimates = (PointEstimate, DistributionEstimate)
     outputs = (SingleOutput, MultiOutput)
-    predict_inputs = (PointPredictInput, PointOrDistributionPredictInput)
 
-    @testset "$est, $out, $pin" for (est, out, pin) in Iterators.product(estimates, outputs, predict_inputs)
-        temp = FakeTemplate{est, out, pin}()
+    @testset "$est, $out, PointPredictInput" for (est, out) in Iterators.product(estimates, outputs)
+        temp = FakeTemplate{est, out}()
         test_interface(temp)
     end    
 
     @testset "Vector inputs case" begin
-        temp = FakeTemplate{PointEstimate, SingleOutput, PointPredictInput}()
+        temp = FakeTemplate{PointEstimate, SingleOutput}()
         test_interface(temp; inputs=[rand(5), rand(5)], outputs=rand(1, 2))
+    end
+
+    @testset "$est, $out, PointOrDistributionPredictInput" for (est, out) in Iterators.product(estimates, outputs)
+        Models.predict_input_type(m::Type{<:FakeTemplate}) = PointOrDistributionPredictInput
+        Models.predict_input_type(m::Type{<:FakeModel}) = PointOrDistributionPredictInput
+
+        temp = FakeTemplate{est, out}()
+        test_interface(temp)
+    end 
+
+    @testset "Vector inputs case" begin
+        temp = FakeTemplate{PointEstimate, SingleOutput}()
+        test_interface(
+            temp; 
+            inputs=[rand(5), rand(5)], 
+            outputs=rand(1, 2), 
+            distribution_inputs=[MvNormal(5, m) for m in 1:2]
+        )
     end
 
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -5,7 +5,7 @@ struct DummyModel <: Model end
 
     estimates = (PointEstimate, DistributionEstimate)
     outputs = (SingleOutput, MultiOutput)
-    
+
     @testset "$est, $out" for (est, out) in Iterators.product(estimates, outputs)
 
         @testset "Errors if traits are not defined" begin
@@ -44,5 +44,4 @@ struct DummyModel <: Model end
             @test predict_input_type(DummyTemplate) == predict_input_type(DummyModel) == pinputs
         end
     end
-
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -35,13 +35,13 @@ struct DummyModel <: Model end
             @test predict_input_type(DummyTemplate) == predict_input_type(DummyModel) == PointPredictInput
         end 
 
-        predict_input = (DistributionPredictInput, PointOrDistributionPredictInput)
-
-        @testset "$pinputs is defined" for pinputs in predict_input
-            predict_input_type(m::Type{<:DummyTemplate}) = pinputs
-            predict_input_type(m::Type{<:DummyModel}) = pinputs
+        @testset "PointOrDistributionPredictInput is defined" begin
+            predict_input_type(m::Type{<:DummyTemplate}) = PointOrDistributionPredictInput
+            predict_input_type(m::Type{<:DummyModel}) = PointOrDistributionPredictInput
             
-            @test predict_input_type(DummyTemplate) == predict_input_type(DummyModel) == pinputs
+            @test predict_input_type(DummyTemplate) == 
+                predict_input_type(DummyModel) == 
+                PointOrDistributionPredictInput
         end
     end
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -29,19 +29,19 @@ struct DummyModel <: Model end
 
     end
 
-    @testset "Inject Trait" begin
+    @testset "PredictInput Trait" begin
         
         @testset "Default" begin
-            @test inject_type(DummyTemplate) == inject_type(DummyModel) == PointInject
+            @test predict_input_type(DummyTemplate) == predict_input_type(DummyModel) == PointPredictInput
         end 
 
-        injects = (DistributionInject, PointOrDistributionInject)
+        predict_input = (DistributionPredictInput, PointOrDistributionPredictInput)
 
-        @testset "$inj is defined" for inj in injects
-            inject_type(m::Type{<:DummyTemplate}) = inj
-            inject_type(m::Type{<:DummyModel}) = inj
+        @testset "$pinputs is defined" for pinputs in predict_input
+            predict_input_type(m::Type{<:DummyTemplate}) = pinputs
+            predict_input_type(m::Type{<:DummyModel}) = pinputs
             
-            @test inject_type(DummyTemplate) == inject_type(DummyModel) == inj
+            @test predict_input_type(DummyTemplate) == predict_input_type(DummyModel) == pinputs
         end
     end
 

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -5,7 +5,7 @@ struct DummyModel <: Model end
 
     estimates = (PointEstimate, DistributionEstimate)
     outputs = (SingleOutput, MultiOutput)
-
+    
     @testset "$est, $out" for (est, out) in Iterators.product(estimates, outputs)
 
         @testset "Errors if traits are not defined" begin
@@ -29,5 +29,20 @@ struct DummyModel <: Model end
 
     end
 
+    @testset "Inject Trait" begin
+        
+        @testset "Default" begin
+            @test inject_type(DummyTemplate) == inject_type(DummyModel) == PointInject
+        end 
+
+        injects = (DistributionInject, PointOrDistributionInject)
+
+        @testset "$inj is defined" for inj in injects
+            inject_type(m::Type{<:DummyTemplate}) = inj
+            inject_type(m::Type{<:DummyModel}) = inj
+            
+            @test inject_type(DummyTemplate) == inject_type(DummyModel) == inj
+        end
+    end
 
 end

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -29,7 +29,7 @@ struct DummyModel <: Model end
 
     end
 
-    @testset "PredictInput Trait" begin
+    @testset "PredictInputTrait" begin
         
         @testset "Default" begin
             @test predict_input_type(DummyTemplate) == predict_input_type(DummyModel) == PointPredictInput


### PR DESCRIPTION
Experimenting with adding an InputTrait to the Models API.  The use case for this trait would be for models that can accept distributions as inputs to the `predict` step.  

Questions for discussion:

1. Is it bad that this `InputTrait` would refer to inputs specifically to `predict`?  Would this cause confusion if for some reason we wanted to use distribution inputs to `fit` in the future?
2. Can this be done in a non-breaking way?